### PR TITLE
Task Priority bug fixed

### DIFF
--- a/server/controllers/ProjectController.js
+++ b/server/controllers/ProjectController.js
@@ -246,7 +246,7 @@ const updateTask = async (req, res, next) => {
       });
     }
 
-    task.taskPriority = req.body.taskPriority;
+    task.taskPriority = (req.body.taskPriority ? req.body.taskPriority : task.taskPriority);
 
     task.taskName = req.body.taskName;
     let num = Object.keys(task.taskComments).length


### PR DESCRIPTION
Issue Type
☑︎ Bug
☐ Feature
☐ Tech Debt

**Description**
Task Priority would be deleted when the task name was edited.

**Steps to Validate Feature**
Run npm run dev to start server
Edit the task name to something else and the task priority should still stay the same.

**Previous behavior**
Changing the task name would turn the task priority into an empty string.